### PR TITLE
Add Python 3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+__pycache__/
 *.pyc

--- a/gpcdump.py
+++ b/gpcdump.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 from gpclib.decode import GPCDecoder
 
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
-        print 'usage: {0} file.gbc'.format(sys.argv[0])
+        print('usage: {0} file.gbc'.format(sys.argv[0]))
         sys.exit(-1)
 
     # read the entire input
@@ -18,13 +19,13 @@ if __name__ == '__main__':
     try:
         decoder.full_decode()
     except ValueError as e:
-        print e
+        print(e)
 
     # print all the opcodes
-    sorted_ops = sorted(decoder.operations.items(), key=lambda i: i[0])
+    sorted_ops = sorted(list(decoder.operations.items()), key=lambda i: i[0])
     for idx, (addr, op) in enumerate(sorted_ops):
         if op._sub:
-            print '{0:0>4X} {1}:'.format(addr, op._sub)
+            print('{0:0>4X} {1}:'.format(addr, op._sub))
         if op._loc:
-            print '{0:0>4X} \t{1}:'.format(addr, op._loc)
-        print '{0:0>4X}\t\t{1}'.format(addr, op)
+            print('{0:0>4X} \t{1}:'.format(addr, op._loc))
+        print('{0:0>4X}\t\t{1}'.format(addr, op))

--- a/gpclib/opcodes.py
+++ b/gpclib/opcodes.py
@@ -30,7 +30,7 @@ class OpCode(object):
         self.size = 0
     
         # check for the correct op code
-        if data[address] != chr(self._op):
+        if data[address] != self._op:
             return self.size
         
         # store the address

--- a/gpctoblocks.py
+++ b/gpctoblocks.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import pprint
 import sys
 from gpclib.decode import GPCDecoder, GPCBlock
 
 
 def print_sink(sink, i = 0):
-    sorted_sources = sorted(sink.sources.items(), key=lambda i: i[0])
+    sorted_sources = sorted(list(sink.sources.items()), key=lambda i: i[0])
     for idx, (addr, source) in enumerate(sorted_sources):
         if hasattr(source, 'sources'):
             print_sink(source, i + 1)
         else:
-            print '{0:0>4X}\t\t\t\t\t{1}{2}'.format(source.address, '\t'*i, source.operation)
-    print '{0:0>4X}\t\t\t\t{1}{2}'.format(sink.address, '\t'*i, sink.operation)
+            print('{0:0>4X}\t\t\t\t\t{1}{2}'.format(source.address, '\t'*i, source.operation))
+    print('{0:0>4X}\t\t\t\t{1}{2}'.format(sink.address, '\t'*i, sink.operation))
 
 def print_block(block, i = 0):
-    print '{0:0>4X} \t{1}b_{0:0>4X}'.format(int(block.address), '\t' * i)
-    for group in sorted(block.groups.values(), key=lambda g: g.address):
+    print('{0:0>4X} \t{1}b_{0:0>4X}'.format(int(block.address), '\t' * i))
+    for group in sorted(list(block.groups.values()), key=lambda g: g.address):
         if isinstance(group, GPCBlock):
             print_block(group, i + 1)
         else:
@@ -28,12 +29,12 @@ def print_block(block, i = 0):
             a = group._jumped or group._jumpzed or -1
             if a > 0:
                 jumped_from = 'g_{0:0>4X} {1}> '.format(a, '-' if group._jumped else '?')
-            print '{0:0>4X} \t\t{3}{2}(g_{0:0>4X}){1}'.format(group.address, jump_to, jumped_from, '\t' * i)
+            print('{0:0>4X} \t\t{3}{2}(g_{0:0>4X}){1}'.format(group.address, jump_to, jumped_from, '\t' * i))
             print_sink(group.final_sink, i)
     
 if __name__ == '__main__':
     if len(sys.argv) != 2:
-        print 'usage: {0} file.gbc'.format(sys.argv[0])
+        print('usage: {0} file.gbc'.format(sys.argv[0]))
         sys.exit(-1)
 
     # read the entire input
@@ -45,9 +46,9 @@ if __name__ == '__main__':
     try:
         decoder.full_decode()
     except ValueError as e:
-        print e
+        print(e)
 
-    subs = decoder.subs.values()
+    subs = list(decoder.subs.values())
     if decoder.init:
         subs.insert(0, decoder.init)
     if decoder.start:
@@ -55,5 +56,5 @@ if __name__ == '__main__':
 
     # print all the subs
     for sub in sorted(subs, key=lambda s: s.address):
-        print '{0:0>4X} {1}:'.format(sub.address, sub.generate_prototype())
+        print('{0:0>4X} {1}:'.format(sub.address, sub.generate_prototype()))
         print_block(sub.root)

--- a/gpctoc.py
+++ b/gpctoc.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 from gpclib.decode import GPCDecoder
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
-        print 'usage: {0} file.gbc'.format(sys.argv[0])
+        print('usage: {0} file.gbc'.format(sys.argv[0]))
         sys.exit(-1)
 
     # read the entire input
@@ -19,7 +20,7 @@ if __name__ == '__main__':
         decoder.combo_decode()
         decoder.init_decode()
     except ValueError as e:
-        print e
+        print(e)
 
     lines = []
 
@@ -38,12 +39,12 @@ if __name__ == '__main__':
     # decompile any allocations
     if decoder.allocs:
         lines.append('// variable segment')
-        for index,count in sorted(decoder.allocs.items(), key=lambda a: a[0]):
+        for index,count in sorted(list(decoder.allocs.items()), key=lambda a: a[0]):
             if index < decoder.combo_count * 3: continue
             if count > 1:
                 lines.append('int v{0}[{1}];'.format(index, count))
             else:
-                if decoder.alloc_values.has_key(index):
+                if index in decoder.alloc_values:
                     lines.append('int {0};'.format(decoder.alloc_values[index]))
                 else:
                     lines.append('int v{0};'.format(index))
@@ -57,7 +58,7 @@ if __name__ == '__main__':
     lines.append('// main segment')
 
     # decompile init and main
-    for sub in sorted(decoder.subs.values(), key=lambda s: s.address):
+    for sub in sorted(list(decoder.subs.values()), key=lambda s: s.address):
         if sub.name not in ('init', 'main'): continue
         lines.append('{0} {{'.format(sub.generate_prototype()))
         for line in sub.decompile():
@@ -77,7 +78,7 @@ if __name__ == '__main__':
 
     header = False
     # decompile the rest of the subs
-    for sub in sorted(decoder.subs.values(), key=lambda s: s.address):
+    for sub in sorted(list(decoder.subs.values()), key=lambda s: s.address):
         if sub.name in ('init', 'main'): continue
         if not header:
             lines.append('// function segment')
@@ -90,4 +91,4 @@ if __name__ == '__main__':
 
     # print all the lines
     for line in lines:
-        print line
+        print(line)

--- a/gpctofgrp.py
+++ b/gpctofgrp.py
@@ -1,21 +1,22 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import sys
 from gpclib.decode import GPCDecoder
 
 
 def print_sink(sink, i = 0):
-    sorted_sources = sorted(sink.sources.items(), key=lambda i: i[0])
+    sorted_sources = sorted(list(sink.sources.items()), key=lambda i: i[0])
     for idx, (addr, source) in enumerate(sorted_sources):
         if hasattr(source, 'sources'):
             print_sink(source, i + 1)
         else:
-            print '{0:0>4X}\t\t\t{1}{2}'.format(source.address, '\t'*i, source.operation)
-    print '{0:0>4X}\t\t{1}{2}'.format(sink.address, '\t'*i, sink.operation)
+            print('{0:0>4X}\t\t\t{1}{2}'.format(source.address, '\t'*i, source.operation))
+    print('{0:0>4X}\t\t{1}{2}'.format(sink.address, '\t'*i, sink.operation))
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:
-        print 'usage: {0} file.gbc'.format(sys.argv[0])
+        print('usage: {0} file.gbc'.format(sys.argv[0]))
         sys.exit(-1)
 
     # read the entire input
@@ -27,9 +28,9 @@ if __name__ == '__main__':
     try:
         decoder.full_decode()
     except ValueError as e:
-        print e
+        print(e)
 
-    subs = decoder.subs.values()
+    subs = list(decoder.subs.values())
     if decoder.init:
         subs.insert(0, decoder.init)
     if decoder.start:
@@ -37,8 +38,8 @@ if __name__ == '__main__':
 
     # print all the subs
     for sub in sorted(subs, key=lambda s: s.address):
-        print '{0:0>4X} {1}:'.format(sub.address, sub.generate_prototype())
-        for group in sorted(sub.groups.values(), key=lambda g: g.address):
+        print('{0:0>4X} {1}:'.format(sub.address, sub.generate_prototype()))
+        for group in sorted(list(sub.groups.values()), key=lambda g: g.address):
             jumped_from = ''
             jump_to = ''
             a = group._jump or group._jumpz or -1
@@ -47,6 +48,6 @@ if __name__ == '__main__':
             a = group._jumped or group._jumpzed or -1
             if a > 0:
                 jumped_from = 'g_{0:0>4X} {1}> '.format(a, '-' if group._jumped else '?')
-            print '{0:0>4X} \t{2}(g_{0:0>4X}){1}'.format(group.address, jump_to, jumped_from)
+            print('{0:0>4X} \t{2}(g_{0:0>4X}){1}'.format(group.address, jump_to, jumped_from))
             sink = group.resolve()
             print_sink(sink)


### PR DESCRIPTION
This PR adds support for Python 3 to all of the included scripts, and has been tested with Python 2.7, 3.6, and 3.7. I haven't tested the original version of these scripts with ancient versions of Python to see what the minimum version is, but this PR requires Python 2.6 or newer.

The changes that were made are:

- [`print`](https://docs.python.org/3/library/functions.html#print) is a function so calling it requires parentheses. [`from __future__ import print_function`](https://docs.python.org/2/library/__future__.html) preserves Python 2 compatibility by opting into the new behavior in Python 2.6+.
- The `has_key` method has been removed from `dict`s. This is fixed by replacing calls to it with the [`in` operator](https://docs.python.org/3/reference/expressions.html#membership-test-operations).
- Calling `items()`, `values()`, etc. on `dict`s returns [view objects](https://docs.python.org/3/library/stdtypes.html#dict-views), not lists. This is fixed by explicitly wrapping the returned value in a [`list` constructor](https://docs.python.org/3/library/functions.html#func-list) which also works without making any changes on Python 2.
- Accessing a byte in binary data by index (such as `self.data[address]`) results in an `int` in Python 3 rather than a single character `str` like Python 2, so using `ord` will result in an error as it only supports single character `str`s. This is fixed by wrapping the data in a [`bytearray` object](https://docs.python.org/3/library/stdtypes.html#bytearray-objects) which behaves identically in Python 2 and 3, and dropping calls to `ord`.